### PR TITLE
refactor(template): change form markup to use correct grid sizes

### DIFF
--- a/dist/contact-detail.html
+++ b/dist/contact-detail.html
@@ -7,28 +7,28 @@
       <form role="form" class="form-horizontal">
         <div class="form-group">
           <label class="col-sm-2 control-label">First Name</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="first name" class="form-control" value.bind="contact.firstName">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Last Name</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="last name" class="form-control" value.bind="contact.lastName">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Email</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="email" class="form-control" value.bind="contact.email">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Phone Nember</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="phone number" class="form-control" value.bind="contact.phoneNumber">
           </div>
         </div>

--- a/src/contact-detail.html
+++ b/src/contact-detail.html
@@ -7,28 +7,28 @@
       <form role="form" class="form-horizontal">
         <div class="form-group">
           <label class="col-sm-2 control-label">First Name</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="first name" class="form-control" value.bind="contact.firstName">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Last Name</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="last name" class="form-control" value.bind="contact.lastName">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Email</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="email" class="form-control" value.bind="contact.email">
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-sm-2 control-label">Phone Nember</label>
-          <div class="col-sm-3">
+          <div class="col-sm-10">
             <input type="text" placeholder="phone number" class="form-control" value.bind="contact.phoneNumber">
           </div>
         </div>


### PR DESCRIPTION
The PR fixes sizing of contact detail form view. The grid used in application is built on the 12-grid. It changes the code to use
correct grid sizes on small screens when rendering form.

Before this PR the contact form breaks on small screens:
![20150127202152](https://cloud.githubusercontent.com/assets/14539/5925257/84dc08b6-a662-11e4-924b-316944d94da9.jpg)

This PR just uses correct grid values to size inputs on small screens:
![20150127202134](https://cloud.githubusercontent.com/assets/14539/5925265/9517190a-a662-11e4-8dbc-46b8f0914e91.jpg)

I've already signed Durandal's CLA.

Thanks!
